### PR TITLE
Add CallUUID Property

### DIFF
--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -16,6 +16,7 @@
 @property (nonatomic, strong) PKPushRegistry *voipRegistry;
 @property (nonatomic, strong) TVOCallInvite *callInvite;
 @property (nonatomic, strong) TVOCall *call;
+@property (nonatomic, strong) UUID *callUUID;
 @property (nonatomic, strong) CXProvider *callKitProvider;
 @property (nonatomic, strong) CXCallController *callKitCallController;
 @end
@@ -25,7 +26,6 @@
   NSMutableDictionary *_callParams;
   NSString *_tokenUrl;
   NSString *_token;
-  NSUUID *_callUUID;
 }
 
 NSString * const StatePending = @"PENDING";
@@ -100,7 +100,7 @@ RCT_EXPORT_METHOD(connect: (NSDictionary *)params) {
 
 RCT_EXPORT_METHOD(disconnect) {
   NSLog(@"Disconnecting call");
-  [self performEndCallActionWithUUID:_callUUID];
+  [self performEndCallActionWithUUID:self.callUUID];
 }
 
 RCT_EXPORT_METHOD(setMuted: (BOOL *)muted) {
@@ -333,7 +333,7 @@ RCT_REMAP_METHOD(getActiveCall,
   }
   [self sendEventWithName:@"connectionDidDisconnect" body:params];
   if (self.call.state == TVOCallStateConnected) {
-    [self performEndCallActionWithUUID:_callUUID];
+    [self performEndCallActionWithUUID:self.callUUID];
   }
   self.call = nil;
 }
@@ -360,7 +360,7 @@ RCT_REMAP_METHOD(getActiveCall,
   [self sendEventWithName:@"connectionDidDisconnect" body:params];
 
   if (self.call.state == TVOCallStateConnected) {
-    [self performEndCallActionWithUUID:_callUUID];
+    [self performEndCallActionWithUUID:self.callUUID];
   }
   self.call = nil;
 }
@@ -421,7 +421,7 @@ RCT_REMAP_METHOD(getActiveCall,
   if (!self.call) {
     [action fail];
   } else {
-    _callUUID = action.callUUID;
+    self.callUUID = action.callUUID;
 
     [action fulfillWithDateStarted:[NSDate date]];
   }
@@ -437,7 +437,7 @@ RCT_REMAP_METHOD(getActiveCall,
 
   self.call = [self.callInvite acceptWithDelegate:self];
   if (self.call) {
-    _callUUID = [action callUUID];
+    self.callUUID = [action callUUID];
   }
 
   self.callInvite = nil;

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -16,7 +16,7 @@
 @property (nonatomic, strong) PKPushRegistry *voipRegistry;
 @property (nonatomic, strong) TVOCallInvite *callInvite;
 @property (nonatomic, strong) TVOCall *call;
-@property (nonatomic, strong) UUID *callUUID;
+@property (nonatomic, strong) NSUUID *callUUID;
 @property (nonatomic, strong) CXProvider *callKitProvider;
 @property (nonatomic, strong) CXCallController *callKitCallController;
 @end

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -515,7 +515,6 @@ RCT_REMAP_METHOD(getActiveCall,
 }
 
 - (void)performEndCallActionWithUUID:(NSUUID *)uuid {
-
   if (uuid == nil) {
     return;
   }

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -25,6 +25,7 @@
   NSMutableDictionary *_callParams;
   NSString *_tokenUrl;
   NSString *_token;
+  NSUUID *_callUUID;
 }
 
 NSString * const StatePending = @"PENDING";
@@ -99,7 +100,7 @@ RCT_EXPORT_METHOD(connect: (NSDictionary *)params) {
 
 RCT_EXPORT_METHOD(disconnect) {
   NSLog(@"Disconnecting call");
-  [self performEndCallActionWithUUID:self.call.uuid];
+  [self performEndCallActionWithUUID:_callUUID];
 }
 
 RCT_EXPORT_METHOD(setMuted: (BOOL *)muted) {
@@ -332,7 +333,7 @@ RCT_REMAP_METHOD(getActiveCall,
   }
   [self sendEventWithName:@"connectionDidDisconnect" body:params];
   if (self.call.state == TVOCallStateConnected) {
-    [self performEndCallActionWithUUID:call.uuid];
+    [self performEndCallActionWithUUID:_callUUID];
   }
   self.call = nil;
 }
@@ -359,7 +360,7 @@ RCT_REMAP_METHOD(getActiveCall,
   [self sendEventWithName:@"connectionDidDisconnect" body:params];
 
   if (self.call.state == TVOCallStateConnected) {
-    [self performEndCallActionWithUUID:call.uuid];
+    [self performEndCallActionWithUUID:_callUUID];
   }
   self.call = nil;
 }
@@ -420,7 +421,7 @@ RCT_REMAP_METHOD(getActiveCall,
   if (!self.call) {
     [action fail];
   } else {
-    self.call.uuid = action.callUUID;
+    _callUUID = action.callUUID;
 
     [action fulfillWithDateStarted:[NSDate date]];
   }
@@ -436,7 +437,7 @@ RCT_REMAP_METHOD(getActiveCall,
 
   self.call = [self.callInvite acceptWithDelegate:self];
   if (self.call) {
-    self.call.uuid = [action callUUID];
+    _callUUID = [action callUUID];
   }
 
   self.callInvite = nil;
@@ -514,6 +515,7 @@ RCT_REMAP_METHOD(getActiveCall,
 }
 
 - (void)performEndCallActionWithUUID:(NSUUID *)uuid {
+
   if (uuid == nil) {
     return;
   }


### PR DESCRIPTION
I was having trouble with calling multiple times in one session on IOS. It appeared that the call was not disconnecting properly after the first call which would lead to errors on any subsequent calls.

Upon further investigation i found that the UUID passed to the performEndCallActionWithUUID method was always null and therefore the method would exit without disconnecting. It appears somewhere the call.uuid is set to null before the disconnect. 

This PR fixes that issue by creating a callUUID property and setting that to the uuid. 
I do not have much experience in Objective C so it is possible i am missing a simpler solution, or misunderstanding the problem. 
