### PR TITLE
Fix iOS HEADER_SEARCH_PATHS

### DIFF
--- a/ios/RNTwilioVoice.xcodeproj/project.pbxproj
+++ b/ios/RNTwilioVoice.xcodeproj/project.pbxproj
@@ -186,10 +186,10 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../../React",
+					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
-					"${SRCROOT}/../../../ios/Pods/Headers/Public/**",
+					"${SRCROOT}/../../../ios/Pods/Headers/Public",
+					"${SRCROOT}/../../../ios/Pods/Headers/Public/TwilioVoice",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -236,10 +236,10 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../../React",
+					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
-					"${SRCROOT}/../../../ios/Pods/Headers/Public/**",
+					"${SRCROOT}/../../../ios/Pods/Headers/Public",
+					"${SRCROOT}/../../../ios/Pods/Headers/Public/TwilioVoice",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
 				MTL_ENABLE_DEBUG_INFO = NO;


### PR DESCRIPTION
It seems that you're allowing all the headers inside the `Pods` directory, `${SRCROOT}/../../../ios/Pods/Headers/Public/**`.

This can potentially create conflicts in the global space. I was able to fix that by only looking in the `TwilioVoice` pod, `${SRCROOT}/../../../ios/Pods/Headers/Public/TwilioVoice`.