### PR TITLE
Disconnect active call on app close

### DIFF
--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
@@ -182,6 +182,8 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
 
     @Override
     public void onHostDestroy() {
+        disconnect();
+        callNotificationManager.removeHangupNotification(getReactApplicationContext());
         unsetAudioFocus();
     }
 


### PR DESCRIPTION
Currently if the client close the app during an active call, the active call isn't disconnected.

This pull request fixes this issue by disconnecting the active call (if exists) and removing the active call notification