### PR TITLE
Validate token type before calling native module

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ const Twilio = {
     // Listen to deviceReady and deviceNotReady events to see whether
     // the initialization succeeded
     async initWithToken(token) {
+        if (typeof token !== 'string') {
+            return { initialized: false, err: 'Invalid token, token must be a string' }
+        };
+
         const result = await TwilioVoice.initWithAccessToken(token)
         // native react promise present only for Android
         // iOS initWithAccessToken doesn't return


### PR DESCRIPTION
if the token type isn't string, we'll receive unhandled exception that isn't possible to catch