### PR TITLE
Fixed NPE in requestPermissionForMicrophone()

### DIFF
--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
@@ -778,12 +778,14 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
     }
 
     private void requestPermissionForMicrophone() {
-        if (ActivityCompat.shouldShowRequestPermissionRationale(getCurrentActivity(), Manifest.permission.RECORD_AUDIO)) {
-//            Snackbar.make(coordinatorLayout,
-//                    "Microphone permissions needed. Please allow in your application settings.",
-//                    SNACKBAR_DURATION).show();
-        } else {
-            ActivityCompat.requestPermissions(getCurrentActivity(), new String[]{Manifest.permission.RECORD_AUDIO}, MIC_PERMISSION_REQUEST_CODE);
+        if (getCurrentActivity() != null) {
+            if (ActivityCompat.shouldShowRequestPermissionRationale(getCurrentActivity(), Manifest.permission.RECORD_AUDIO)) {
+    //            Snackbar.make(coordinatorLayout,
+    //                    "Microphone permissions needed. Please allow in your application settings.",
+    //                    SNACKBAR_DURATION).show();
+            } else {
+                ActivityCompat.requestPermissions(getCurrentActivity(), new String[]{Manifest.permission.RECORD_AUDIO}, MIC_PERMISSION_REQUEST_CODE);
+            }
         }
     }
 }


### PR DESCRIPTION
Should `requestPermissionForMicrophone()` be called before an activity is displayed an NPE will occur and it will crash the app. This PR prevents that by checking if `getCurrentActivity()` is null, if it is then `requestPermissionForMicrophone()` will not run. This has been an issue for an application I am working on and having this included in [react-native-twilio-programmable-voice](https://github.com/hoxfon/react-native-twilio-programmable-voice) would be helpful as it would not require developers to manually do this.