### PR TITLE
Add compatibility with iOS VOIP notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ platform :ios, '8.1'
 
 target <YOUR_TARGET> do
     ...
-    pod 'TwilioVoice', '~> 2.0.0'
+    pod 'TwilioVoice', '~> 2.1.0'
     ...
 end
 
@@ -109,7 +109,7 @@ platform :ios, '8.1'
 
 target <YOUR_TARGET> do
     ...
-    pod 'TwilioVoice', '~> 2.0.0'
+    pod 'TwilioVoice', '~> 2.1.0'
     pod 'RNTwilioVoice', path: '../node_modules/react-native-twilio-programmable-voice'
     ...
 end

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -213,7 +213,12 @@ RCT_REMAP_METHOD(getActiveCall,
   NSLog(@"pushRegistry:didUpdatePushCredentials:forType");
 
   if ([type isEqualToString:PKPushTypeVoIP]) {
-    self.deviceTokenString = [credentials.token description];
+    const unsigned *tokenBytes = [credentials.token bytes];
+    self.deviceTokenString = [NSString stringWithFormat:@"<%08x %08x %08x %08x %08x %08x %08x %08x>", 
+                                                        ntohl(tokenBytes[0]), ntohl(tokenBytes[1]), ntohl(tokenBytes[2]),
+                                                        ntohl(tokenBytes[3]), ntohl(tokenBytes[4]), ntohl(tokenBytes[5]),
+                                                        ntohl(tokenBytes[6]), ntohl(tokenBytes[7])];
+
     NSString *accessToken = [self fetchAccessToken];
 
     [TwilioVoice registerWithAccessToken:accessToken


### PR DESCRIPTION
This provides a way to use VOIP functionalities to the client, by sending back the iOS VOIP token and notifications payload (through `deviceReady` and `deviceDidReceiveIncoming`).
This is because this library is not compatible with libraries such as [ianlin/react-native-voip-push-notification](https://github.com/ianlin/react-native-voip-push-notification) (They both implement the same methods).
This allows user to retain similar capabilities with this library (Sending VOIP notifications from their servers too, not just Twilio's).

_Original commit message:_
```
Add compatibility with iOS VOIP notifications

Send voip token to client in deviceReady callback
Use deviceDidReceiveIncoming to transfer notification payload to client
```