### PR TITLE
iOS: Upgrade TwilioVoice pod to version 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ platform :ios, '8.1'
 
 target <YOUR_TARGET> do
     ...
-    pod 'TwilioVoice', '~> 2.0.0'
+    pod 'TwilioVoice', '~> 2.1.0'
     ...
 end
 
@@ -109,7 +109,7 @@ platform :ios, '8.1'
 
 target <YOUR_TARGET> do
     ...
-    pod 'TwilioVoice', '~> 2.0.0'
+    pod 'TwilioVoice', '~> 2.1.0'
     pod 'RNTwilioVoice', path: '../node_modules/react-native-twilio-programmable-voice'
     ...
 end

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -213,7 +213,12 @@ RCT_REMAP_METHOD(getActiveCall,
   NSLog(@"pushRegistry:didUpdatePushCredentials:forType");
 
   if ([type isEqualToString:PKPushTypeVoIP]) {
-    self.deviceTokenString = [credentials.token description];
+    const unsigned *tokenBytes = [credentials.token bytes];
+    self.deviceTokenString = [NSString stringWithFormat:@"<%08x %08x %08x %08x %08x %08x %08x %08x>", 
+                                                        ntohl(tokenBytes[0]), ntohl(tokenBytes[1]), ntohl(tokenBytes[2]),
+                                                        ntohl(tokenBytes[3]), ntohl(tokenBytes[4]), ntohl(tokenBytes[5]),
+                                                        ntohl(tokenBytes[6]), ntohl(tokenBytes[7])];
+
     NSString *accessToken = [self fetchAccessToken];
 
     [TwilioVoice registerWithAccessToken:accessToken


### PR DESCRIPTION
Fixes iOS incompatibility with Xcode 11 & iOS 13

Closes #128 

[Twilio Changelog](https://www.twilio.com/docs/voice/voip-sdk/ios/changelog)
```
Xcode 11 & iOS 13 Compatability Notice

Our Voice iOS SDKs versions 2.0.x, 3.x and 4.x are not compatible with Apps built using Xcode 11 and installed on iOS 13.

For 2.0.x releases, please upgrade to the 2.1 release

For 3.x and 4.x release, please upgrade to 5.0 release

Please refer to this advisory and this GitHub issue for more information.
```