### PR TITLE
Switch from rnpm to react-native.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,6 @@
     "type": "git",
     "url": "git+ssh://git@github.com:hoxfon/react-native-twilio-programmable-voice.git"
   },
-  "rnpm": {
-    "android": {
-      "packageInstance": "new TwilioVoicePackage()"
-    }
-  },
   "author": {
     "name": "Fabrizio Moscon"
   },

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  project: {
+    ios: {},
+    android: {
+      packageInstance: "new TwilioVoicePackage()"
+    }
+  }
+};


### PR DESCRIPTION
This resolves Metro Bundler warnings:
```
The following packages use deprecated "rnpm" config that will stop working from next release:
...
- react-native-twilio-programmable-voice: https://github.com/hoxfon/react-native-twilio-programmable-voice
Please notify their maintainers about it. You can find more details at https://github.com/react-native-community/cli/blob/master/docs/configuration.md#migration-guide.
```
This also addresses issue [#131](https://github.com/hoxfon/react-native-twilio-programmable-voice/issues/131) from @josaric. 