### PR TITLE
Clear Cached Device Token on Unregister

### DIFF
--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -146,10 +146,14 @@ RCT_EXPORT_METHOD(unregister) {
   NSString *accessToken = [self fetchAccessToken];
   NSString *cachedDeviceToken = [[NSUserDefaults standardUserDefaults] objectForKey:kCachedDeviceToken];
   if ([cachedDeviceToken length] > 0) {
+      /* Clear the device token when unregistering. */
+      [[NSUserDefaults standardUserDefaults] setObject:@"" forKey:kCachedDeviceToken];
       [TwilioVoice unregisterWithAccessToken:accessToken
                                  deviceToken:cachedDeviceToken
                                   completion:^(NSError * _Nullable error) {
                                     if (error) {
+                                        /* Undo token clear on failure */
+                                        [[NSUserDefaults standardUserDefaults] setObject:cachedDeviceToken forKey:kCachedDeviceToken];
                                         NSLog(@"An error occurred while unregistering: %@", [error localizedDescription]);
                                     } else {
                                         NSLog(@"Successfully unregistered for VoIP push notifications.");
@@ -270,10 +274,14 @@ RCT_REMAP_METHOD(getCallInvite,
 
     NSString *cachedDeviceToken = [[NSUserDefaults standardUserDefaults] objectForKey:kCachedDeviceToken];
     if ([cachedDeviceToken length] > 0) {
+        /* Clear the device token when unregistering. */
+        [[NSUserDefaults standardUserDefaults] setObject:@"" forKey:kCachedDeviceToken];
         [TwilioVoice unregisterWithAccessToken:accessToken
                                                 deviceToken:cachedDeviceToken
                                                  completion:^(NSError * _Nullable error) {
                                                    if (error) {
+                                                     /* Undo token clear on failure */
+                                                     [[NSUserDefaults standardUserDefaults] setObject:cachedDeviceToken forKey:kCachedDeviceToken];
                                                      NSLog(@"An error occurred while unregistering: %@", [error localizedDescription]);
                                                    } else {
                                                      NSLog(@"Successfully unregistered for VoIP push notifications.");

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -147,7 +147,7 @@ RCT_EXPORT_METHOD(unregister) {
   NSString *cachedDeviceToken = [[NSUserDefaults standardUserDefaults] objectForKey:kCachedDeviceToken];
   if ([cachedDeviceToken length] > 0) {
       /* Clear the device token when unregistering. */
-      [[NSUserDefaults standardUserDefaults] setObject:@"" forKey:kCachedDeviceToken];
+      [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedDeviceToken];
       [TwilioVoice unregisterWithAccessToken:accessToken
                                  deviceToken:cachedDeviceToken
                                   completion:^(NSError * _Nullable error) {
@@ -275,7 +275,7 @@ RCT_REMAP_METHOD(getCallInvite,
     NSString *cachedDeviceToken = [[NSUserDefaults standardUserDefaults] objectForKey:kCachedDeviceToken];
     if ([cachedDeviceToken length] > 0) {
         /* Clear the device token when unregistering. */
-        [[NSUserDefaults standardUserDefaults] setObject:@"" forKey:kCachedDeviceToken];
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedDeviceToken];
         [TwilioVoice unregisterWithAccessToken:accessToken
                                                 deviceToken:cachedDeviceToken
                                                  completion:^(NSError * _Nullable error) {


### PR DESCRIPTION
- When unregistering the access token with Twilio, the cached device token should also be cleared so that the app can then re-register when reinitializing with a new token. In the event that the unregistration call results in an error, the cached token is restored