### PR TITLE
feat: Android: set min SDK version to 23

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath 'com.google.gms:google-services:4.3.3'
+        classpath 'com.android.tools.build:gradle:3.5.4'
+        classpath 'com.google.gms:google-services:4.3.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -23,10 +23,11 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
-def DEFAULT_TARGET_SDK_VERSION = 28
-def DEFAULT_SUPPORT_LIB_VERSION = "28.0.3"
+def DEFAULT_MIN_SDK_VERSION = 23
+def DEFAULT_COMPILE_SDK_VERSION = 30
+def DEFAULT_BUILD_TOOLS_VERSION = "29.0.3"
+def DEFAULT_TARGET_SDK_VERSION = 29
+def DEFAULT_SUPPORT_LIB_VERSION = "29.0.3"
 
 android {
     compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
@@ -36,7 +37,7 @@ android {
         targetCompatibility 1.8
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEFAULT_MIN_SDK_VERSION
         targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
In preparation of bigger changes, we should set the minSDKVersion for Android to 23