### PR TITLE
fix: (iOS) always disable proximityMonitor when the call is disconnected

### DIFF
--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -515,6 +515,9 @@ withCompletionHandler:(void (^)(void))completion {
         NSLog(@"didDisconnect");
     }
 
+    UIDevice* device = [UIDevice currentDevice];
+    device.proximityMonitoringEnabled = NO;
+
     if (!self.userInitiatedDisconnect) {
         CXCallEndedReason reason = CXCallEndedReasonRemoteEnded;
         if (error) {
@@ -734,8 +737,6 @@ withCompletionHandler:(void (^)(void))completion {
   if (uuid == nil) {
     return;
   }
-  UIDevice* device = [UIDevice currentDevice];
-  device.proximityMonitoringEnabled = NO;
 
   CXEndCallAction *endCallAction = [[CXEndCallAction alloc] initWithCallUUID:uuid];
   CXTransaction *transaction = [[CXTransaction alloc] initWithAction:endCallAction];


### PR DESCRIPTION
As mentioned in previous review, the current method for disabling the proximityMonitor is not always triggered.

https://github.com/hoxfon/react-native-twilio-programmable-voice/pull/144#pullrequestreview-454135844

This PR is also part of the larger Android CallKeep PR which runs in production in our current app. As seen here: https://github.com/hoxfon/react-native-twilio-programmable-voice/pull/157/files#diff-45656eb5e0a849d5962bf607be0a256dc13c9db8fc67de4ee8340c3f76f6d438R520-R521