### PR TITLE
Showing caller's name in CallKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ cd ios/ && pod install
 
 The iOS library works through [CallKit](https://developer.apple.com/reference/callkit) and handling calls is much simpler than the  Android implementation as CallKit handles the inbound calls answering, ignoring, or rejecting. Outbound calls must be controlled by custom React-Native screens and controls.
 
+To pass caller's name to CallKit via voip push notification add custom parameter 'CallerName' to Twilio Dial verb.
+```xml
+    <Dial>
+    <Client>
+        <Identity>Client</Identity>
+        <Parameter name="CallerName">NAME TO DISPLAY</Parameter>
+    </Client>
+    </Dial>
+```    
+
 #### VoIP Service Certificate
 
 Twilio Programmable Voice for iOS utilizes Apple's VoIP Services and VoIP "Push Notifications" instead of FCM. You will need a VoIP Service Certificate from Apple to receive calls. Follow [the official Twilio instructions](https://github.com/twilio/voice-quickstart-ios#7-create-voip-service-certificate) to complete this step.

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -726,7 +726,8 @@ withCompletionHandler:(void (^)(void))completion {
 
 - (void)reportIncomingCallFrom:(NSString *)from withUUID:(NSUUID *)uuid {
   CXHandleType type = [[from substringToIndex:1] isEqual:@"+"] ? CXHandleTypePhoneNumber : CXHandleTypeGeneric;
-  CXHandle *callHandle = [[CXHandle alloc] initWithType:type value:from];
+  // lets replace 'client:' with ''
+  CXHandle *callHandle = [[CXHandle alloc] initWithType:type value:[from stringByReplacingOccurrencesOfString:@"client:" withString:@""]];
 
   CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
   callUpdate.remoteHandle = callHandle;

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -347,6 +347,9 @@ withCompletionHandler:(void (^)(void))completion {
     if (callInvite.from) {
         from = [callInvite.from stringByReplacingOccurrencesOfString:@"client:" withString:@""];
     }
+    if (callInvite.customParameters[@"CallerName"]) {
+        from = callInvite.customParameters[@"CallerName"];
+    }
     // Always report to CallKit
     [self reportIncomingCallFrom:from withUUID:callInvite.uuid];
     self.activeCallInvites[[callInvite.uuid UUIDString]] = callInvite;
@@ -722,7 +725,8 @@ withCompletionHandler:(void (^)(void))completion {
 }
 
 - (void)reportIncomingCallFrom:(NSString *)from withUUID:(NSUUID *)uuid {
-  CXHandle *callHandle = [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:from];
+  CXHandleType type = [[from substringToIndex:1] isEqual:@"+"] ? CXHandleTypePhoneNumber : CXHandleTypeGeneric;
+  CXHandle *callHandle = [[CXHandle alloc] initWithType:type value:from];
 
   CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
   callUpdate.remoteHandle = callHandle;

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -11,6 +11,7 @@
 @import TwilioVoice;
 
 NSString * const kCachedDeviceToken = @"CachedDeviceToken";
+NSString * const kCallerNameCustomParameter = @"CallerName";
 
 @interface RNTwilioVoice () <PKPushRegistryDelegate, TVONotificationDelegate, TVOCallDelegate, CXProviderDelegate>
 
@@ -347,8 +348,8 @@ withCompletionHandler:(void (^)(void))completion {
     if (callInvite.from) {
         from = [callInvite.from stringByReplacingOccurrencesOfString:@"client:" withString:@""];
     }
-    if (callInvite.customParameters[@"CallerName"]) {
-        from = callInvite.customParameters[@"CallerName"];
+    if (callInvite.customParameters[kCallerNameCustomParameter]) {
+        from = callInvite.customParameters[kCallerNameCustomParameter];
     }
     // Always report to CallKit
     [self reportIncomingCallFrom:from withUUID:callInvite.uuid];


### PR DESCRIPTION
I made simple changes to display the caller's name in CallKit and iPhone's call log.
You can now pass CallerName parameter to Dial verb to display the desired name. This is useful when calling 'client:xxx'.
When it is not passed and callInvite.from starts with a "+" (it is a number) it sets the correct type, CXHandleTypePhoneNumber. That way number is formatted by the iPhone and it will lookup the name in your contacts.