### PR TITLE
(iOS) Add handler to hold/unhold call

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ const Twilio = {
     setMuted: TwilioVoice.setMuted,
     setSpeakerPhone: TwilioVoice.setSpeakerPhone,
     sendDigits: TwilioVoice.sendDigits,
-    hold: TwilioVoice.hold,
+    hold: TwilioVoice.setOnHold,
     requestPermissions(senderId) {
         if (Platform.OS === ANDROID) {
             TwilioVoice.requestPermissions(senderId)

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -130,6 +130,11 @@ RCT_EXPORT_METHOD(setMuted: (BOOL *)muted) {
     self.activeCall.muted = muted ? YES : NO;
 }
 
+RCT_EXPORT_METHOD(setOnHold: (BOOL *)isOnHold) {
+  NSLog(@"Hold/Unhold call");
+    self.activeCall.onHold = isOnHold ? YES : NO;
+}
+
 RCT_EXPORT_METHOD(setSpeakerPhone: (BOOL *)speaker) {
     [self toggleAudioRoute: speaker ? YES : NO];
 }


### PR DESCRIPTION
- current version throws an error for hold functionality because the handler is not present in `RNTwilioVoice.m ` file.
- Adding this seems to fix the issue.