### PR TITLE
Update hold example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ TwilioVoice.ignore()
 TwilioVoice.setMuted(mutedValue)
 
 // put a call on hold
-TwilioVoice.setOnHold(holdValue)
+TwilioVoice.hold(holdValue)
 
 // send digits
 TwilioVoice.sendDigits(digits)


### PR DESCRIPTION
Hi all!

I noticed that `TwilioVoice.setMuted(mutedValue)` in README seems outdated because there's no such method, but `TwilioVoice.hold(mutedValue)`  