### PR TITLE
Fixed bug on unregistration (ios)

### DIFF
--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -158,6 +158,7 @@ RCT_EXPORT_METHOD(unregister) {
                                     if (error) {
                                         NSLog(@"An error occurred while unregistering: %@", [error localizedDescription]);
                                     } else {
+                                      [[NSUserDefaults standardUserDefaults] setValue:@"" forKey:kCachedDeviceToken];
                                         NSLog(@"Successfully unregistered for VoIP push notifications.");
                                     }
                                 }];
@@ -282,6 +283,7 @@ RCT_REMAP_METHOD(getCallInvite,
                                                    if (error) {
                                                      NSLog(@"An error occurred while unregistering: %@", [error localizedDescription]);
                                                    } else {
+                                                     [[NSUserDefaults standardUserDefaults] setValue:@"" forKey:kCachedDeviceToken];
                                                      NSLog(@"Successfully unregistered for VoIP push notifications.");
                                                    }
                                                  }];

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -158,7 +158,7 @@ RCT_EXPORT_METHOD(unregister) {
                                     if (error) {
                                         NSLog(@"An error occurred while unregistering: %@", [error localizedDescription]);
                                     } else {
-                                      [[NSUserDefaults standardUserDefaults] setValue:@"" forKey:kCachedDeviceToken];
+                                        [[NSUserDefaults standardUserDefaults] setValue:@"" forKey:kCachedDeviceToken];
                                         NSLog(@"Successfully unregistered for VoIP push notifications.");
                                     }
                                 }];


### PR DESCRIPTION
Hi guys!

We faced with the following issue: when TwilioVoice.unregister() is called we are not able to register the device again with TwilioVoice.initWithToken(). 

I found out that it happens because when we try to register device again, we compare if cachedDeviceToken has changed versus actual deviceTokenString. And we are able to register PushNotifications only if our Device tokes was changed.

...
(line 245 in RNTwilioVoice.m) if (![cachedDeviceToken isEqualToString:deviceTokenString]) {
...

But when we unregister the device we are not changing the cached token in memory, so when we try to register Pushes again, library compare the cashed token (which was not changed) vs actual deviceTokenString (which is still the same as well). As a result we are not able to register Push notifications.

Proposed solution: when TwilioVoice.unregister() is called, and the unregistration was successfull, we should clear the cashed device token. It allows us to register device again.

Hope you will reply soon.
Roma


