### PR TITLE
Sends deviceReady event when using Cached token

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,12 @@ TwilioVoice.getCallInvite()
 
 // Unregister device with Twilio (iOS only)
 TwilioVoice.unregister()
+
+// Sets Twilio Voice edge location.
+// See [Edge Reference](https://www.twilio.com/docs/voice/client/edges) for more information.
+// See [Public Edge Locations](https://www.twilio.com/docs/global-infrastructure/edge-locations#public-edge-locations) for public edge locations.
+// And [Private Interconnect Locations](https://www.twilio.com/docs/global-infrastructure/edge-locations#private-interconnect) for private connections.
+TwilioVoice.setEdge(location)
 ```
 
 ## Help wanted

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
@@ -810,6 +810,13 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
         }
     }
 
+    @ReactMethod
+    public void setEdge(String location) {
+        if (!location.isEmpty()) {
+            Voice.setEdge(location);
+        }
+    }
+
     private void setAudioFocus() {
         if (audioManager == null) {
             audioManager.setMode(originalAudioMode);

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
@@ -810,13 +810,6 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
         }
     }
 
-    @ReactMethod
-    public void setEdge(String location) {
-        if (!location.isEmpty()) {
-            Voice.setEdge(location);
-        }
-    }
-
     private void setAudioFocus() {
         if (audioManager == null) {
             audioManager.setMode(originalAudioMode);

--- a/ios/RNTwilioVoice/RNTwilioVoice.h
+++ b/ios/RNTwilioVoice/RNTwilioVoice.h
@@ -7,5 +7,6 @@
 #import <React/RCTEventEmitter.h>
 
 @interface RNTwilioVoice : RCTEventEmitter <RCTBridgeModule>
-
+- (void)initPushRegistry;
+- (void)configureCallKit: (NSDictionary *)params;
 @end

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -681,6 +681,14 @@ withCompletionHandler:(void (^)(void))completion {
     }
 }
 
+- (void)provider:(CXProvider *)provider performPlayDTMFCallAction:(CXPlayDTMFCallAction *)action {
+  TVOCall *call = self.activeCalls[action.callUUID.UUIDString];
+  if (call && call.state == TVOCallStateConnected) {
+    RCTLogInfo(@"SendDigits %@", action.digits);
+    [call sendDigits:action.digits];
+  }
+}
+
 #pragma mark - CallKit Actions
 - (void)performStartCallActionWithUUID:(NSUUID *)uuid handle:(NSString *)handle {
   if (uuid == nil || handle == nil) {

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -258,6 +258,8 @@ RCT_REMAP_METHOD(getCallInvite,
                  [self sendEventWithName:@"deviceReady" body:nil];
              }
          }];
+    } else {
+        [self sendEventWithName:@"deviceReady" body:nil];
     }
   }
 }
@@ -731,6 +733,12 @@ withCompletionHandler:(void (^)(void))completion {
   callUpdate.supportsGrouping = NO;
   callUpdate.supportsUngrouping = NO;
   callUpdate.hasVideo = NO;
+
+  if ([from containsString:@"client:"]) {
+    callUpdate.localizedCallerName = @"Seguridad";
+  } else {
+    callUpdate.localizedCallerName = @"Visitante";
+  }
 
   [self.callKitProvider reportNewIncomingCallWithUUID:uuid update:callUpdate completion:^(NSError *error) {
     if (!error) {

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -684,7 +684,7 @@ withCompletionHandler:(void (^)(void))completion {
 - (void)provider:(CXProvider *)provider performPlayDTMFCallAction:(CXPlayDTMFCallAction *)action {
   TVOCall *call = self.activeCalls[action.callUUID.UUIDString];
   if (call && call.state == TVOCallStateConnected) {
-    RCTLogInfo(@"SendDigits %@", action.digits);
+    NSLog(@"SendDigits %@", action.digits);
     [call sendDigits:action.digits];
   }
 }

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -734,12 +734,6 @@ withCompletionHandler:(void (^)(void))completion {
   callUpdate.supportsUngrouping = NO;
   callUpdate.hasVideo = NO;
 
-  if ([from containsString:@"client:"]) {
-    callUpdate.localizedCallerName = @"Seguridad";
-  } else {
-    callUpdate.localizedCallerName = @"Visitante";
-  }
-
   [self.callKitProvider reportNewIncomingCallWithUUID:uuid update:callUpdate completion:^(NSError *error) {
     if (!error) {
       NSLog(@"Incoming call successfully reported");


### PR DESCRIPTION
Some applications may rely on the deviceReady event to be thrown to understand the VOIP functionality is ready. When using the cached token the lib was not sending the deviceReady event.
This PR fixes that.