### PR TITLE
Twilio android sdk 5 bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ TwilioVoice.getCallInvite()
         }
     })
 
-// Unregister device with Twilio (iOS only)
+// Unregister device with Twilio
 TwilioVoice.unregister()
 ```
 

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/Constants.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/Constants.java
@@ -26,6 +26,8 @@ public class Constants {
     public static final String ACTION_FCM_TOKEN = "ACTION_FCM_TOKEN";
     public static final String ACTION_CLEAR_MISSED_CALLS_COUNT = "CLEAR_MISSED_CALLS_COUNT";
     public static final String ACTION_OPEN_CALL_IN_PROGRESS = "CALL_IN_PROGRESS";
+    public static final String ACTION_ANSWER = "ACTION_ANSWER";
+    public static final String ACTION_DECLINE = "ACTION_DECLINE";
 
     public static final String CALL_SID = "call_sid";
     public static final String CALL_STATE = "call_state";

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/Constants.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/Constants.java
@@ -26,8 +26,8 @@ public class Constants {
     public static final String ACTION_FCM_TOKEN = "ACTION_FCM_TOKEN";
     public static final String ACTION_CLEAR_MISSED_CALLS_COUNT = "CLEAR_MISSED_CALLS_COUNT";
     public static final String ACTION_OPEN_CALL_IN_PROGRESS = "CALL_IN_PROGRESS";
-    public static final String ACTION_ANSWER = "ACTION_ANSWER";
-    public static final String ACTION_DECLINE = "ACTION_DECLINE";
+    public static final String ACTION_JS_ANSWER = "ACTION_JS_ANSWER";
+    public static final String ACTION_JS_REJECT = "ACTION_JS_REJECT";
 
     public static final String CALL_SID = "call_sid";
     public static final String CALL_STATE = "call_state";

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/Constants.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/Constants.java
@@ -26,8 +26,8 @@ public class Constants {
     public static final String ACTION_FCM_TOKEN = "ACTION_FCM_TOKEN";
     public static final String ACTION_CLEAR_MISSED_CALLS_COUNT = "CLEAR_MISSED_CALLS_COUNT";
     public static final String ACTION_OPEN_CALL_IN_PROGRESS = "CALL_IN_PROGRESS";
-    public static final String ACTION_JS_ANSWER = "ACTION_JS_ANSWER";
-    public static final String ACTION_JS_REJECT = "ACTION_JS_REJECT";
+    public static final String ACTION_ANSWER = "ACTION_ANSWER";
+    public static final String ACTION_DECLINE = "ACTION_DECLINE";
 
     public static final String CALL_SID = "call_sid";
     public static final String CALL_STATE = "call_state";

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/IncomingCallNotificationService.java
@@ -63,11 +63,11 @@ public class IncomingCallNotificationService extends Service {
                 handleCancelledCall(intent);
                 break;
 
-            case Constants.ACTION_ANSWER:
+            case Constants.ACTION_JS_ANSWER:
                 endForeground();
                 break;   
 
-            case Constants.ACTION_DECLINE:
+            case Constants.ACTION_JS_REJECT:
                 endForeground();
                 break;    
 

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/IncomingCallNotificationService.java
@@ -63,6 +63,14 @@ public class IncomingCallNotificationService extends Service {
                 handleCancelledCall(intent);
                 break;
 
+            case Constants.ACTION_ANSWER:
+                endForeground();
+                break;   
+
+            case Constants.ACTION_DECLINE:
+                endForeground();
+                break;    
+
             default:
                 break;
         }
@@ -246,6 +254,7 @@ public class IncomingCallNotificationService extends Service {
     }
 
     private void reject(CallInvite callInvite, int notificationId) {
+        SoundPoolManager.getInstance(this).stopRinging();
         endForeground();
         callInvite.reject(getApplicationContext());
     }

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/IncomingCallNotificationService.java
@@ -63,11 +63,11 @@ public class IncomingCallNotificationService extends Service {
                 handleCancelledCall(intent);
                 break;
 
-            case Constants.ACTION_JS_ANSWER:
+            case Constants.ACTION_ANSWER:
                 endForeground();
                 break;   
 
-            case Constants.ACTION_JS_REJECT:
+            case Constants.ACTION_DECLINE:
                 endForeground();
                 break;    
 

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
@@ -743,7 +743,7 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
         }
 
         Intent intent = new Intent(getReactApplicationContext(), IncomingCallNotificationService.class);
-        intent.setAction(Constants.ACTION_JS_ANSWER);
+        intent.setAction(Constants.ACTION_ANSWER);
 
         getReactApplicationContext().startService(intent);
 
@@ -765,7 +765,7 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
         }
         
         Intent intent = new Intent(getReactApplicationContext(), IncomingCallNotificationService.class);
-        intent.setAction(Constants.ACTION_JS_REJECT);
+        intent.setAction(Constants.ACTION_DECLINE);
         
         getReactApplicationContext().startService(intent);
 

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
@@ -237,7 +237,7 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
         };
     }
 
-    private UnregistrationListener unregistrationListener() {    //
+    private UnregistrationListener unregistrationListener() {   
         return new UnregistrationListener() {
             @Override
             public void onUnregistered(String accessToken, String fcmToken) {

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
@@ -50,6 +50,7 @@ import com.twilio.voice.ConnectOptions;
 import com.twilio.voice.LogLevel;
 import com.twilio.voice.RegistrationException;
 import com.twilio.voice.RegistrationListener;
+import com.twilio.voice.UnregistrationListener;
 import com.twilio.voice.Voice;
 
 import java.util.HashSet;
@@ -93,6 +94,7 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
     static Map<String, Integer> callNotificationMap;
 
     private RegistrationListener registrationListener = registrationListener();
+    private UnregistrationListener unregistrationListener = unregistrationListener(); 
     private Call.Listener callListener = callListener();
 
     private CallInvite activeCallInvite;
@@ -230,6 +232,27 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
                 Log.e(TAG, String.format("RegistrationListener().onError(). Code: %d. %s", error.getErrorCode(), error.getMessage()));
                 WritableMap params = Arguments.createMap();
                 params.putString(Constants.ERROR, error.getMessage());
+                eventManager.sendEvent(EVENT_DEVICE_NOT_READY, params);
+            }
+        };
+    }
+
+    private UnregistrationListener unregistrationListener() {    //
+        return new UnregistrationListener() {
+            @Override
+            public void onUnregistered(String accessToken, String fcmToken) {
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "Successfully unregistered FCM");
+                }
+                // eventManager.sendEvent(EVENT_DEVICE_UNREGISTERED, null);
+                eventManager.sendEvent(EVENT_DEVICE_NOT_READY, null);
+            }
+
+            @Override
+            public void onError(RegistrationException error, String accessToken, String fcmToken) {
+                Log.e(TAG, String.format("Unregistration Error: %d, %s", error.getErrorCode(), error.getMessage()));
+                WritableMap params = Arguments.createMap();
+                params.putString("err", error.getMessage());
                 eventManager.sendEvent(EVENT_DEVICE_NOT_READY, params);
             }
         };
@@ -659,6 +682,41 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
         Voice.register(accessToken, Voice.RegistrationChannel.FCM, fcmToken, registrationListener);
     }
 
+     /*
+     * Unregister your android device with Twilio
+     *
+     */
+
+    @ReactMethod  //
+    public void unregister(Promise promise) {
+        unregisterForCallInvites();
+        WritableMap params = Arguments.createMap();
+        params.putBoolean("initialized", false);
+        promise.resolve(params);
+    }
+
+    private void unregisterForCallInvites() {
+        FirebaseInstanceId.getInstance().getInstanceId()
+                .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+                    @Override
+                    public void onComplete(@NonNull Task<InstanceIdResult> task) {
+                        if (!task.isSuccessful()) {
+                            Log.w(TAG, "getInstanceId failed", task.getException());
+                            return;
+                        }
+
+                        // Get new Instance ID token
+                        String fcmToken = task.getResult().getToken();
+                        if (fcmToken != null) {
+                            if (BuildConfig.DEBUG) {
+                                Log.d(TAG, "Unregistering with FCM");
+                            }
+                            Voice.unregister(accessToken, Voice.RegistrationChannel.FCM, fcmToken, unregistrationListener);
+                        }
+                    }
+                });
+    }
+
     public void acceptFromIntent(Intent intent) {
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "acceptFromIntent()");
@@ -687,6 +745,12 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "accept()");
         }
+
+        Intent intent = new Intent(getReactApplicationContext(), IncomingCallNotificationService.class);
+        intent.setAction(Constants.ACTION_ANSWER);
+
+        getReactApplicationContext().startService(intent);
+
         AcceptOptions acceptOptions = new AcceptOptions.Builder()
                 .enableDscp(true)
                 .build();
@@ -703,6 +767,12 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
             params.putString(Constants.CALL_TO,    activeCallInvite.getTo());
             activeCallInvite.reject(getReactApplicationContext());
         }
+        
+        Intent intent = new Intent(getReactApplicationContext(), IncomingCallNotificationService.class);
+        intent.setAction(Constants.ACTION_DECLINE);
+        
+        getReactApplicationContext().startService(intent);
+
         eventManager.sendEvent(EVENT_CALL_INVITE_CANCELLED, params);
         activeCallInvite = null;
     }

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
@@ -244,15 +244,13 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
                 if (BuildConfig.DEBUG) {
                     Log.d(TAG, "Successfully unregistered FCM");
                 }
-                // eventManager.sendEvent(EVENT_DEVICE_UNREGISTERED, null);
-                eventManager.sendEvent(EVENT_DEVICE_NOT_READY, null);
             }
 
             @Override
             public void onError(RegistrationException error, String accessToken, String fcmToken) {
                 Log.e(TAG, String.format("Unregistration Error: %d, %s", error.getErrorCode(), error.getMessage()));
                 WritableMap params = Arguments.createMap();
-                params.putString("err", error.getMessage());
+                params.putString(Constants.ERROR, error.getMessage());
                 eventManager.sendEvent(EVENT_DEVICE_NOT_READY, params);
             }
         };
@@ -690,9 +688,7 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
     @ReactMethod  //
     public void unregister(Promise promise) {
         unregisterForCallInvites();
-        WritableMap params = Arguments.createMap();
-        params.putBoolean("initialized", false);
-        promise.resolve(params);
+        promise.resolve(true);
     }
 
     private void unregisterForCallInvites() {
@@ -701,7 +697,7 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
                     @Override
                     public void onComplete(@NonNull Task<InstanceIdResult> task) {
                         if (!task.isSuccessful()) {
-                            Log.w(TAG, "getInstanceId failed", task.getException());
+                            Log.w(TAG, "FCM unregistration failed", task.getException());
                             return;
                         }
 
@@ -747,7 +743,7 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
         }
 
         Intent intent = new Intent(getReactApplicationContext(), IncomingCallNotificationService.class);
-        intent.setAction(Constants.ACTION_ANSWER);
+        intent.setAction(Constants.ACTION_JS_ANSWER);
 
         getReactApplicationContext().startService(intent);
 
@@ -769,7 +765,7 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
         }
         
         Intent intent = new Intent(getReactApplicationContext(), IncomingCallNotificationService.class);
-        intent.setAction(Constants.ACTION_DECLINE);
+        intent.setAction(Constants.ACTION_JS_REJECT);
         
         getReactApplicationContext().startService(intent);
 

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
@@ -743,7 +743,7 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
         }
 
         Intent intent = new Intent(getReactApplicationContext(), IncomingCallNotificationService.class);
-        intent.setAction(Constants.ACTION_ANSWER);
+        intent.setAction(Constants.ACTION_JS_ANSWER);
 
         getReactApplicationContext().startService(intent);
 
@@ -765,7 +765,7 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
         }
         
         Intent intent = new Intent(getReactApplicationContext(), IncomingCallNotificationService.class);
-        intent.setAction(Constants.ACTION_DECLINE);
+        intent.setAction(Constants.ACTION_JS_REJECT);
         
         getReactApplicationContext().startService(intent);
 

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/TwilioVoiceModule.java
@@ -249,9 +249,6 @@ public class TwilioVoiceModule extends ReactContextBaseJavaModule implements Act
             @Override
             public void onError(RegistrationException error, String accessToken, String fcmToken) {
                 Log.e(TAG, String.format("Unregistration Error: %d, %s", error.getErrorCode(), error.getMessage()));
-                WritableMap params = Arguments.createMap();
-                params.putString(Constants.ERROR, error.getMessage());
-                eventManager.sendEvent(EVENT_DEVICE_NOT_READY, params);
             }
         };
     }

--- a/index.js
+++ b/index.js
@@ -86,9 +86,7 @@ const Twilio = {
         }
     },
     unregister() {
-        if (Platform.OS === IOS) {
-            TwilioVoice.unregister()
-        }
+        TwilioVoice.unregister()
     },
     // getAudioDevices returns all audio devices connected
     // {

--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -154,6 +154,7 @@ RCT_EXPORT_METHOD(unregister) {
                                     if (error) {
                                         NSLog(@"An error occurred while unregistering: %@", [error localizedDescription]);
                                     } else {
+                                        [[NSUserDefaults standardUserDefaults] setValue:@"" forKey:kCachedDeviceToken];
                                         NSLog(@"Successfully unregistered for VoIP push notifications.");
                                     }
                                 }];
@@ -278,6 +279,7 @@ RCT_REMAP_METHOD(getCallInvite,
                                                    if (error) {
                                                      NSLog(@"An error occurred while unregistering: %@", [error localizedDescription]);
                                                    } else {
+                                                     [[NSUserDefaults standardUserDefaults] setValue:@"" forKey:kCachedDeviceToken];
                                                      NSLog(@"Successfully unregistered for VoIP push notifications.");
                                                    }
                                                  }];


### PR DESCRIPTION
Guys, thank you for your work!

This PR fixes and adds the following functional:
1. Added unregistration for android
2. Fixed unregistration for IOS
3. Solved issue:
" Call invite heads-up notification are not auto cancelled. This issue happens when a call is received and the screen is locked or the screen in unlocked, but the app is in the background. The heads-up notification service is started. If the user taps on the notification full screen content (not reject nor answer button), and then accepts the call from JS, at the end of the call the heads-up notification won't be removed, because there is no push notification for end call, just for call invite cancelled by the caller. I don't know how to solve this issue, because endForeground() can only be called by the service and all the user interactions from JS end are handled by the VoiceModule. At the same time full screen content is needed to show the JS incoming call screen when the phone is locked, therefore it can't be removed.  "
4. Solved a bug with infinite ringing.

Please feel free to contact me in case of questions)