### PR TITLE
fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ async function initTelephony() {
 }
 
 function initTelephonyWithToken(token) {
-    TwilioVoice.initWithAccessToken(token)
+    TwilioVoice.initWithToken(token)
 
     // iOS only, configure CallKit
     try {


### PR DESCRIPTION
The `TwilioVoice` provided by `react-native-twilio-programmable-voice` does not have a function `initWithAccessToken`.

Using `initWithToken` instead worked fine.